### PR TITLE
boost-1.67 fixes

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -41,7 +41,8 @@
 #include <boost/utility/value_init.hpp>
 #include <boost/asio/deadline_timer.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp> // TODO
-#include <boost/thread/v2/thread.hpp> // TODO
+#include <boost/thread/thread.hpp> // TODO
+#include <boost/thread/condition_variable.hpp> // TODO
 #include "misc_language.h"
 #include "pragma_comp_defs.h"
 

--- a/contrib/epee/include/syncobj.h
+++ b/contrib/epee/include/syncobj.h
@@ -31,10 +31,11 @@
 #define __WINH_OBJ_H__
 
 #include <boost/chrono/duration.hpp>
+#include <boost/thread/condition_variable.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
-#include <boost/thread/v2/thread.hpp>
+#include <boost/thread/thread.hpp>
 
 namespace epee
 {

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -1589,7 +1589,7 @@ void WalletImpl::refreshThreadFunc()
         // if auto refresh enabled, we wait for the "m_refreshIntervalSeconds" interval.
         // if not - we wait forever
         if (m_refreshIntervalMillis > 0) {
-            boost::posix_time::milliseconds wait_for_ms(m_refreshIntervalMillis);
+            boost::posix_time::milliseconds wait_for_ms(m_refreshIntervalMillis.load());
             m_refreshCV.timed_wait(lock, wait_for_ms);
         } else {
             m_refreshCV.wait(lock);


### PR DESCRIPTION
This is a couple of commits from Monero necessary for building under gcc-8 and boost 1.67 (but that will work fine under earlier gcc/boost versions).

The first resolves a change introduced by boost 1.67 only accepting literal integer types as the argument to `boost::posix_time::milliseconds` (and similar) instead of allowing implicitly convertible integers as was the case in earlier boost versions.  Thus passing an `std::atomic<int>` is no longer allowed.

The second commit removes the use of a long-deprecated (and removed, as of boost 1.67) header, replacing it with the proper replacements.