### PR TITLE
Switch v10 difficulty algorithm back to v8

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -780,7 +780,7 @@ difficulty_type Blockchain::get_difficulty_for_next_block()
   {
       return next_difficulty(timestamps, difficulties, target);
   }
-  else if (version == 8)
+  else if (version == 8 || version >= 10)
   {
       return next_difficulty_v8(timestamps, difficulties, target);
   }


### PR DESCRIPTION
The difficulty tweak added in v9 makes the difficulty drop too fast, but only *after* the difficulty has already been dropping for 3 blocks.

This causes two problems: first, difficulty drops too fast and by too much.  Second we get considerably more erratic block times than we should be getting as a result.  Second, because this adjustment is applied asymmetrically (it can only decrease diff but never increase it), it results in long run average difficulty coming in consistently too low, making average block times (and thus daily emissions) a little fast.

As to the first point: Zawy DA already drops quite fast after a long block, but the v9 adjustment makes it drop even faster.  The end result is that we see a consistent pattern for months now of "coin hopping": a large hashrate (estimated at about 2-4x times the collective hashrate of known pools) jumps into Graft mining when difficulty drops, scooping up around 10 or so easy blocks until it drives the difficulty back up. This added hash then departs as quickly as it arrived, leaving the network with considerably less actual hashrate than the current network difficulty is configured for, thus inducing some long blocks, which starts the difficulty plummeting all over again.

The bigger problem with this is that it is leading to never-ending cycles of exceptionally long blocks times followed by brief bursts of exceptionally short block times.  Overall we're seeing about 30% more blocks under 1 minute than we should ideally see, and more than five times as many blocks over 15 minutes (212 since block 100K, while we should have seen around 37).

This distribution isn't entirely due to the v9 adjustment, but the v9 adjustment is exacerbating the problem.

This commit restores the DA back to the v8 algorithm (but keeps the FTL and median timestamp changes that v9 added).

Fixes #133 

There is some more discussion (including a histogram of solve times since block 100K) in #133.