### PR TITLE
Syslog logging support added

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,13 @@ endif()
 set(CMAKE_C_FLAGS_RELEASE "-DNDEBUG ${OPT_FLAGS_RELEASE}")
 set(CMAKE_CXX_FLAGS_RELEASE "-DNDEBUG ${OPT_FLAGS_RELEASE}")
 
+if(NOT DEFINED CMAKE_ROOT_SOURCE_DIR)
+# CMAKE_ROOT_SOURCE_DIR variable is required, because CMAKE_SOURCE_DIR works well for include like commands and does not for external projects
+    set(CMAKE_ROOT_SOURCE_DIR "${CMAKE_SOURCE_DIR}")
+endif()
+
+add_definitions(-DELPP_SYSLOG -DMONERO_DEFAULT_LOG_CATEGORY="cryptonode" -DCMAKE_ROOT_SOURCE_DIR="${CMAKE_ROOT_SOURCE_DIR}")
+
 # set this to 0 if per-block checkpoint needs to be disabled
 set(PER_BLOCK_CHECKPOINT 0)
 

--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -55,16 +55,53 @@
 #define MONERO_DEFAULT_LOG_CATEGORY "default"
 #endif
 
-#define MCFATAL(cat,x) CLOG(FATAL,cat) << x
-#define MCERROR(cat,x) CLOG(ERROR,cat) << x
-#define MCWARNING(cat,x) CLOG(WARNING,cat) << x
-#define MCINFO(cat,x) CLOG(INFO,cat) << x
-#define MCDEBUG(cat,x) CLOG(DEBUG,cat) << x
-#define MCTRACE(cat,x) CLOG(TRACE,cat) << x
+#ifdef __cplusplus
+#if __cplusplus >= 201103L
+
+#define MONERO_LOG_CATEGORY mlog_current_log_category.empty()? MONERO_DEFAULT_LOG_CATEGORY : std::string(mlog_current_log_category.c_str()).c_str()
+
+// Define MONERO_DEFAULT_LOG_CATEGORY in your unit code to direct logging to
+// a category for whole unit. Set mlog_current_log_category to direct logging
+// to a particular category, then clear it to switch back to the category that
+// is set for the unit.
+
+extern thread_local std::string mlog_current_log_category;
+
+#endif //__cplusplus >= 201103L
+#endif //__cplusplus
+
+#ifndef MONERO_LOG_CATEGORY
+#define MONERO_LOG_CATEGORY MONERO_DEFAULT_LOG_CATEGORY
+#endif
+
+#ifdef ELPP_SYSLOG
+
+extern bool mlog_syslog;
+#define CLOGX(LEVEL,cat) ((mlog_syslog)? CSYSLOG(LEVEL,cat) : CLOG(LEVEL,cat))
+#define MCLOG(level,cat,x) ELPP_WRITE_LOG(el::base::Writer, level, \
+    (mlog_syslog)? el::base::DispatchAction::SysLog : el::base::DispatchAction::NormalLog \
+    , cat) << x
+
+#define MCLOG_COLOR(level,cat,color,x) MCLOG(level,cat, ((mlog_syslog)? "" : "\033[1;" color "m") << x << ((mlog_syslog)? "" : "\033[0m"))
+
+#else //ELPP_SYSLOG
+
+#define CLOGX(LEVEL,cat) CLOG(LEVEL,cat)
 #define MCLOG(level,cat,x) ELPP_WRITE_LOG(el::base::Writer, level, el::base::DispatchAction::NormalLog, cat) << x
-#define MCLOG_FILE(level,cat,x) ELPP_WRITE_LOG(el::base::Writer, level, el::base::DispatchAction::FileOnlyLog, cat) << x
 
 #define MCLOG_COLOR(level,cat,color,x) MCLOG(level,cat,"\033[1;" color "m" << x << "\033[0m")
+
+#endif //ELPP_SYSLOG
+
+#define MCFATAL(cat,x) CLOGX(FATAL,cat) << x
+#define MCERROR(cat,x) CLOGX(ERROR,cat) << x
+#define MCWARNING(cat,x) CLOGX(WARNING,cat) << x
+#define MCINFO(cat,x) CLOGX(INFO,cat) << x
+#define MCDEBUG(cat,x) CLOGX(DEBUG,cat) << x
+#define MCTRACE(cat,x) CLOGX(TRACE,cat) << x
+
+#define MCLOG_FILE(level,cat,x) ELPP_WRITE_LOG(el::base::Writer, level, el::base::DispatchAction::FileOnlyLog, cat) << x
+
 #define MCLOG_RED(level,cat,x) MCLOG_COLOR(level,cat,"31",x)
 #define MCLOG_GREEN(level,cat,x) MCLOG_COLOR(level,cat,"32",x)
 #define MCLOG_YELLOW(level,cat,x) MCLOG_COLOR(level,cat,"33",x)
@@ -72,20 +109,20 @@
 #define MCLOG_MAGENTA(level,cat,x) MCLOG_COLOR(level,cat,"35",x)
 #define MCLOG_CYAN(level,cat,x) MCLOG_COLOR(level,cat,"36",x)
 
-#define MLOG_RED(level,x) MCLOG_RED(level,MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_GREEN(level,x) MCLOG_GREEN(level,MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_YELLOW(level,x) MCLOG_YELLOW(level,MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_BLUE(level,x) MCLOG_BLUE(level,MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_MAGENTA(level,x) MCLOG_MAGENTA(level,MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MLOG_CYAN(level,x) MCLOG_CYAN(level,MONERO_DEFAULT_LOG_CATEGORY,x)
+#define MLOG_RED(level,x) MCLOG_RED(level,MONERO_LOG_CATEGORY,x)
+#define MLOG_GREEN(level,x) MCLOG_GREEN(level,MONERO_LOG_CATEGORY,x)
+#define MLOG_YELLOW(level,x) MCLOG_YELLOW(level,MONERO_LOG_CATEGORY,x)
+#define MLOG_BLUE(level,x) MCLOG_BLUE(level,MONERO_LOG_CATEGORY,x)
+#define MLOG_MAGENTA(level,x) MCLOG_MAGENTA(level,MONERO_LOG_CATEGORY,x)
+#define MLOG_CYAN(level,x) MCLOG_CYAN(level,MONERO_LOG_CATEGORY,x)
 
-#define MFATAL(x) MCFATAL(MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MERROR(x) MCERROR(MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MWARNING(x) MCWARNING(MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MINFO(x) MCINFO(MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MDEBUG(x) MCDEBUG(MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MTRACE(x) MCTRACE(MONERO_DEFAULT_LOG_CATEGORY,x)
-#define MLOG(level,x) MCLOG(level,MONERO_DEFAULT_LOG_CATEGORY,x)
+#define MFATAL(x) MCFATAL(MONERO_LOG_CATEGORY,x)
+#define MERROR(x) MCERROR(MONERO_LOG_CATEGORY,x)
+#define MWARNING(x) MCWARNING(MONERO_LOG_CATEGORY,x)
+#define MINFO(x) MCINFO(MONERO_LOG_CATEGORY,x)
+#define MDEBUG(x) MCDEBUG(MONERO_LOG_CATEGORY,x)
+#define MTRACE(x) MCTRACE(MONERO_LOG_CATEGORY,x)
+#define MLOG(level,x) MCLOG(level,MONERO_LOG_CATEGORY,x)
 
 #define MGINFO(x) MCINFO("global",x)
 #define MGINFO_RED(x) MCLOG_RED(el::Level::Info, "global",x)
@@ -129,6 +166,11 @@ void mlog_configure(const std::string &filename_base, bool console);
 void mlog_set_categories(const char *categories);
 void mlog_set_log_level(int level);
 void mlog_set_log(const char *log);
+
+// %rfile custom specifier can be used in addition to the Logging Format Specifiers of the Easylogging++
+// %rfile similar to %file but the path is relative to topmost CMakeLists.txt
+//the default format is "%datetime{%Y-%M-%d %H:%m:%s.%g}	%thread	%level	%logger	%loc	%msg"
+void mlog_set_format(const char* format);
 
 namespace epee
 {

--- a/contrib/epee/src/CMakeLists.txt
+++ b/contrib/epee/src/CMakeLists.txt
@@ -32,6 +32,8 @@ else()
   add_library(epee STATIC hex.cpp http_auth.cpp mlog.cpp string_tools.cpp memwipe.c async_state_machine.cpp)
 endif()
 
+target_compile_definitions(epee PRIVATE -DELPP_SYSLOG)
+
 if(HAVE_C11)
 SET_PROPERTY(SOURCE memwipe.c PROPERTY COMPILE_FLAGS -std=c11)
 endif()

--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -195,17 +195,17 @@ void mlog_set_log(const char *log)
 //the default format is "%datetime{%Y-%M-%d %H:%m:%s.%g}	%thread	%level	%logger	%loc	%msg"
 void mlog_set_format(const char* format)
 {
-    auto rfile = [](const el::LogMessage* lm)-> std::string
-    {
-        assert(sizeof(CMAKE_ROOT_SOURCE_DIR) < lm->file().size());
-        return lm->file().substr(sizeof(CMAKE_ROOT_SOURCE_DIR));
-    };
-    el::Helpers::installCustomFormatSpecifier(el::CustomFormatSpecifier("%rfile", rfile));
+  auto rfile = [](const el::LogMessage* lm)-> std::string
+  {
+    assert(sizeof(CMAKE_ROOT_SOURCE_DIR) < lm->file().size());
+    return lm->file().substr(sizeof(CMAKE_ROOT_SOURCE_DIR));
+  };
+  el::Helpers::installCustomFormatSpecifier(el::CustomFormatSpecifier("%rfile", rfile));
 
-    el::Configurations defaultConf;
-    defaultConf.setToDefault();
-    defaultConf.setGlobally(el::ConfigurationType::Format, format);
-    el::Loggers::setDefaultConfigurations(defaultConf, true);
+  el::Configurations defaultConf;
+  defaultConf.setToDefault();
+  defaultConf.setGlobally(el::ConfigurationType::Format, format);
+  el::Loggers::setDefaultConfigurations(defaultConf, true);
 }
 
 namespace epee

--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -39,6 +39,12 @@
 
 #define MLOG_LOG(x) CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,MONERO_DEFAULT_LOG_CATEGORY) << x
 
+thread_local std::string mlog_current_log_category;
+
+#ifdef ELPP_SYSLOG
+bool mlog_syslog = false;
+#endif
+
 using namespace epee;
 
 static std::string generate_log_filename(const char *base)
@@ -182,6 +188,24 @@ void mlog_set_log(const char *log)
   {
     MERROR("Invalid numerical log level: " << log);
   }
+}
+
+// %rfile custom specifier can be used in addition to the Logging Format Specifiers of the Easylogging++
+// %rfile similar to %file but the path is relative to topmost CMakeLists.txt
+//the default format is "%datetime{%Y-%M-%d %H:%m:%s.%g}	%thread	%level	%logger	%loc	%msg"
+void mlog_set_format(const char* format)
+{
+    auto rfile = [](const el::LogMessage* lm)-> std::string
+    {
+        assert(sizeof(CMAKE_ROOT_SOURCE_DIR) < lm->file().size());
+        return lm->file().substr(sizeof(CMAKE_ROOT_SOURCE_DIR));
+    };
+    el::Helpers::installCustomFormatSpecifier(el::CustomFormatSpecifier("%rfile", rfile));
+
+    el::Configurations defaultConf;
+    defaultConf.setToDefault();
+    defaultConf.setGlobally(el::ConfigurationType::Format, format);
+    el::Loggers::setDefaultConfigurations(defaultConf, true);
 }
 
 namespace epee

--- a/external/easylogging++/CMakeLists.txt
+++ b/external/easylogging++/CMakeLists.txt
@@ -34,6 +34,8 @@ SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 find_package(Threads)
 
+add_definitions(-DELPP_SYSLOG)
+
 add_library(easylogging
   easylogging++.cc)
 

--- a/src/daemon/command_line_args.h
+++ b/src/daemon/command_line_args.h
@@ -41,6 +41,11 @@ namespace daemon_args
   , "Specify configuration file"
   , std::string(CRYPTONOTE_NAME ".conf")
   };
+  const command_line::arg_descriptor<std::string> arg_log_format = {
+    "log-format"
+  , "Specify log format"
+  , ""
+  };
   const command_line::arg_descriptor<std::string> arg_log_file = {
     "log-file"
   , "Specify log file"

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -205,16 +205,16 @@ int main(int argc, char const * argv[])
     bf::path log_file_path {data_dir / std::string(CRYPTONOTE_NAME ".log")};
     if (! vm["log-file"].defaulted())
       log_file_path = command_line::get_arg(vm, daemon_args::arg_log_file);
-    if(log_file_path == "syslog")
+    if (log_file_path == "syslog")
     {//redirect log to syslog
-        ELPP_INITIALIZE_SYSLOG("graftnoded", LOG_PID, LOG_USER);
-        mlog_syslog = true;
-        mlog_configure("", false);
+      ELPP_INITIALIZE_SYSLOG("graftnoded", LOG_PID, LOG_USER);
+      mlog_syslog = true;
+      mlog_configure("", false);
     }
     else
     {
-        log_file_path = bf::absolute(log_file_path, relative_path_base);
-        mlog_configure(log_file_path.string(), true);
+      log_file_path = bf::absolute(log_file_path, relative_path_base);
+      mlog_configure(log_file_path.string(), true);
     }
 
     // Set log level
@@ -224,9 +224,9 @@ int main(int argc, char const * argv[])
     }
 
     // Set log format
-    if (vm.count("log-format"))
+    if (!vm["log-format"].defaulted())
     {
-        mlog_set_format(command_line::get_arg(vm, daemon_args::arg_log_format).c_str());
+      mlog_set_format(command_line::get_arg(vm, daemon_args::arg_log_format).c_str());
     }
 
     // after logs initialized

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, char const * argv[])
       // Settings
       bf::path default_log = default_data_dir / std::string(CRYPTONOTE_NAME ".log");
       command_line::add_arg(core_settings, daemon_args::arg_log_file, default_log.string());
+      command_line::add_arg(core_settings, daemon_args::arg_log_format);
       command_line::add_arg(core_settings, daemon_args::arg_log_level);
       command_line::add_arg(core_settings, daemon_args::arg_max_concurrency);
 
@@ -204,13 +205,28 @@ int main(int argc, char const * argv[])
     bf::path log_file_path {data_dir / std::string(CRYPTONOTE_NAME ".log")};
     if (! vm["log-file"].defaulted())
       log_file_path = command_line::get_arg(vm, daemon_args::arg_log_file);
-    log_file_path = bf::absolute(log_file_path, relative_path_base);
-    mlog_configure(log_file_path.string(), true);
+    if(log_file_path == "syslog")
+    {//redirect log to syslog
+        ELPP_INITIALIZE_SYSLOG("graftnoded", LOG_PID, LOG_USER);
+        mlog_syslog = true;
+        mlog_configure("", false);
+    }
+    else
+    {
+        log_file_path = bf::absolute(log_file_path, relative_path_base);
+        mlog_configure(log_file_path.string(), true);
+    }
 
     // Set log level
     if (!vm["log-level"].defaulted())
     {
       mlog_set_log(command_line::get_arg(vm, daemon_args::arg_log_level).c_str());
+    }
+
+    // Set log format
+    if (vm.count("log-format"))
+    {
+        mlog_set_format(command_line::get_arg(vm, daemon_args::arg_log_format).c_str());
     }
 
     // after logs initialized


### PR DESCRIPTION
Added graftnoded command line support:
--log-file=syslog command line parameter redirects logging to the syslog
--log-format sets logging format; new custom format specifier %rfile outputs file path relative to topmost CMakeLists.txt

Example:
./graftnoded --log-format="%datetime{%Y-%M-%d %H:%m:%s.%g} %level %logger %rfile %msg" --log-file=syslog
see output in /var/log/syslog