### PR TITLE
Logging support

### DIFF
--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -144,15 +144,13 @@ extern thread_local std::string mlog_current_log_category;
 #endif
 
 std::string mlog_get_default_log_path(const char *default_filename);
-void mlog_configure(const std::string &filename_base, bool console);
-void mlog_set_categories(const char *categories);
-void mlog_set_log_level(int level);
-void mlog_set_log(const char *log);
 
 // %rfile custom specifier can be used in addition to the Logging Format Specifiers of the Easylogging++
 // %rfile similar to %file but the path is relative to topmost CMakeLists.txt
-//the default format is "%datetime{%Y-%M-%d %H:%m:%s.%g}	%thread	%level	%logger	%loc	%msg"
-void mlog_set_format(const char* format);
+void mlog_configure(const std::string &filename_base, bool console, const char* format = nullptr);
+void mlog_set_categories(const char *categories);
+void mlog_set_log_level(int level);
+void mlog_set_log(const char *log);
 
 namespace epee
 {

--- a/src/daemon/main.cpp
+++ b/src/daemon/main.cpp
@@ -206,18 +206,20 @@ int main(int argc, char const * argv[])
     if (! vm["log-file"].defaulted())
       log_file_path = command_line::get_arg(vm, daemon_args::arg_log_file);
     log_file_path = bf::absolute(log_file_path, relative_path_base);
-    mlog_configure(log_file_path.string(), true);
+
+    // Set log format
+    std::string format;
+    if (!vm["log-format"].defaulted())
+    {
+      format = command_line::get_arg(vm, daemon_args::arg_log_format).c_str();
+    }
+
+    mlog_configure(log_file_path.string(), true, format.empty()? nullptr : format.c_str());
 
     // Set log level
     if (!vm["log-level"].defaulted())
     {
       mlog_set_log(command_line::get_arg(vm, daemon_args::arg_log_level).c_str());
-    }
-
-    // Set log format
-    if (!vm["log-format"].defaulted())
-    {
-      mlog_set_format(command_line::get_arg(vm, daemon_args::arg_log_format).c_str());
     }
 
     // after logs initialized


### PR DESCRIPTION
Complete logging support added (without syslog support)

- mlog_configure sets format

- mlog_set_log can be used to set categories logging level