### PR TITLE
Keep alive timeout for connection_base

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -143,6 +143,7 @@ namespace net_utils
     virtual bool add_ref();
     virtual bool release();
     //------------------------------------------------------
+    virtual void on_recv_timeout() override;
     boost::shared_ptr<connection<t_protocol_handler> > safe_shared_from_this();
     bool shutdown();
     /// Handle completion of a read operation.

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -273,6 +273,12 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler>
+  void connection<t_protocol_handler>::on_recv_timeout()
+  {
+    close();
+  }
+  //---------------------------------------------------------------------------------
+  template<class t_protocol_handler>
   void connection<t_protocol_handler>::handle_read(const boost::system::error_code& e,
     std::size_t bytes_transferred)
   {
@@ -311,6 +317,8 @@ PRAGMA_WARNING_DISABLE_VS(4355)
 //			} while(delay > 0);
 		} // any form of sleeping
 		
+      update_last_recv_time();
+
       //_info("[sock " << socket_.native_handle() << "] RECV " << bytes_transferred);
       logger_handle_net_read(bytes_transferred);
       context.m_last_recv = time(NULL);
@@ -556,6 +564,7 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   template<class t_protocol_handler>
   bool connection<t_protocol_handler>::shutdown()
   {
+    connection_basic::cancel_keep_alive_timer();
     // Initiate graceful connection closure.
     boost::system::error_code ignored_ec;
     socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);

--- a/src/p2p/connection_basic.hpp
+++ b/src/p2p/connection_basic.hpp
@@ -133,6 +133,20 @@ class connection_basic { // not-templated base class for rapid developmet of som
 		static double get_sleep_time(size_t cb);
 		
 		static void set_save_graph(bool save_graph);
+
+    protected:
+      void cancel_keep_alive_timer();
+      boost::posix_time::time_duration since_last_recv();
+      void update_last_recv_time();
+
+    private:
+      void start_keep_alive_timer();
+      virtual void on_recv_timeout() = 0;
+
+    private:
+      boost::asio::deadline_timer m_keep_alive_timer;
+      critical_section m_last_recv_lock;
+      boost::posix_time::ptime m_last_recv_time;
 };
 
 } // nameserver


### PR DESCRIPTION
This fix provides possibility to remove hung connections which have no incoming activity during 30 seconds.