### PR TITLE
Revert "Keep alive timeout for connection_base"

### DIFF
--- a/contrib/epee/include/net/abstract_tcp_server2.h
+++ b/contrib/epee/include/net/abstract_tcp_server2.h
@@ -143,7 +143,6 @@ namespace net_utils
     virtual bool add_ref();
     virtual bool release();
     //------------------------------------------------------
-    virtual void on_recv_timeout() override;
     boost::shared_ptr<connection<t_protocol_handler> > safe_shared_from_this();
     bool shutdown();
     /// Handle completion of a read operation.

--- a/contrib/epee/include/net/abstract_tcp_server2.inl
+++ b/contrib/epee/include/net/abstract_tcp_server2.inl
@@ -273,12 +273,6 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   }
   //---------------------------------------------------------------------------------
   template<class t_protocol_handler>
-  void connection<t_protocol_handler>::on_recv_timeout()
-  {
-    close();
-  }
-  //---------------------------------------------------------------------------------
-  template<class t_protocol_handler>
   void connection<t_protocol_handler>::handle_read(const boost::system::error_code& e,
     std::size_t bytes_transferred)
   {
@@ -317,8 +311,6 @@ PRAGMA_WARNING_DISABLE_VS(4355)
 //			} while(delay > 0);
 		} // any form of sleeping
 		
-      update_last_recv_time();
-
       //_info("[sock " << socket_.native_handle() << "] RECV " << bytes_transferred);
       logger_handle_net_read(bytes_transferred);
       context.m_last_recv = time(NULL);
@@ -564,7 +556,6 @@ PRAGMA_WARNING_DISABLE_VS(4355)
   template<class t_protocol_handler>
   bool connection<t_protocol_handler>::shutdown()
   {
-    connection_basic::cancel_keep_alive_timer();
     // Initiate graceful connection closure.
     boost::system::error_code ignored_ec;
     socket_.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);

--- a/src/p2p/connection_basic.cpp
+++ b/src/p2p/connection_basic.cpp
@@ -83,8 +83,6 @@
 #undef MONERO_DEFAULT_LOG_CATEGORY
 #define MONERO_DEFAULT_LOG_CATEGORY "net.p2p"
 
-static const int KEEP_ALIVE_TIMEOUT_SECONDS = 40;
-
 // ################################################################################################
 // local (TU local) headers
 // ################################################################################################
@@ -155,8 +153,7 @@ connection_basic::connection_basic(boost::asio::io_service& io_service, std::ato
 	socket_(io_service),
 	m_want_close_connection(false), 
 	m_was_shutdown(false),
-	m_ref_sock_count(ref_sock_count),
-    m_keep_alive_timer(io_service)
+	m_ref_sock_count(ref_sock_count)
 { 
 	++ref_sock_count; // increase the global counter
 	mI->m_peer_number = sock_number.fetch_add(1); // use, and increase the generated number
@@ -164,16 +161,11 @@ connection_basic::connection_basic(boost::asio::io_service& io_service, std::ato
 	string remote_addr_str = "?";
 	try { boost::system::error_code e; remote_addr_str = socket_.remote_endpoint(e).address().to_string(); } catch(...){} ;
 
-    update_last_recv_time();
-    start_keep_alive_timer();
-
 	_note("Spawned connection p2p#"<<mI->m_peer_number<<" to " << remote_addr_str << " currently we have sockets count:" << m_ref_sock_count);
 	//boost::filesystem::create_directories("log/dr-monero/net/");
 }
 
 connection_basic::~connection_basic() noexcept(false) {
-    cancel_keep_alive_timer();
-
 	string remote_addr_str = "?";
 	m_ref_sock_count--;
 	try { boost::system::error_code e; remote_addr_str = socket_.remote_endpoint(e).address().to_string(); } catch(...){} ;
@@ -312,44 +304,6 @@ double connection_basic::get_sleep_time(size_t cb) {
 void connection_basic::set_save_graph(bool save_graph) {
 }
 
-boost::posix_time::time_duration connection_basic::since_last_recv()
-{
-  CRITICAL_REGION_LOCAL(m_last_recv_lock);
-  return boost::posix_time::second_clock::local_time() - m_last_recv_time;
-}
-
-void connection_basic::update_last_recv_time()
-{
-  CRITICAL_REGION_LOCAL(m_last_recv_lock);
-  m_last_recv_time = boost::posix_time::second_clock::local_time();
-}
-
-void connection_basic::start_keep_alive_timer()
-{
-  m_keep_alive_timer.expires_from_now(boost::posix_time::seconds(KEEP_ALIVE_TIMEOUT_SECONDS));
-  m_keep_alive_timer.async_wait(strand_.wrap([&](const boost::system::error_code& ec)
-  {
-    if(ec == boost::asio::error::operation_aborted)
-      return;
-
-    boost::posix_time::time_duration since_last_recv = this->since_last_recv();
-
-    if(since_last_recv <= boost::posix_time::seconds(KEEP_ALIVE_TIMEOUT_SECONDS))
-    {
-      start_keep_alive_timer();
-      return;
-    }
-
-    MINFO("Timeout on handle_recv, timeout: " << since_last_recv << "s");
-
-    on_recv_timeout();
-  }));
-}
-
-void connection_basic::cancel_keep_alive_timer()
-{
-  m_keep_alive_timer.cancel();
-}
 
 } // namespace
 } // namespace

--- a/src/p2p/connection_basic.hpp
+++ b/src/p2p/connection_basic.hpp
@@ -133,20 +133,6 @@ class connection_basic { // not-templated base class for rapid developmet of som
 		static double get_sleep_time(size_t cb);
 		
 		static void set_save_graph(bool save_graph);
-
-    protected:
-      void cancel_keep_alive_timer();
-      boost::posix_time::time_duration since_last_recv();
-      void update_last_recv_time();
-
-    private:
-      void start_keep_alive_timer();
-      virtual void on_recv_timeout() = 0;
-
-    private:
-      boost::asio::deadline_timer m_keep_alive_timer;
-      critical_section m_last_recv_lock;
-      boost::posix_time::ptime m_last_recv_time;
 };
 
 } // nameserver


### PR DESCRIPTION
Reverts graft-project/GraftNetwork#199

This PR being merged causes all sorts of supernode -> node communication failures:

```
Dec 15 14:09:54 keynes graft_server[1320090]: 2018-12-15 18:09:54.764	    7f4f86b31700	WARN 	net.http	home/jgr/src/GraftNetwork/src/wallet/wallet_errors.h:724	/home/jgr/src/GraftNetwork/src/wallet/wallet2.cpp:1269:N5tools5error23no_connection_to_daemonE: no connection to daemon, request = getblocks.bin
Dec 15 14:09:54 keynes graft_server[1320090]: 2018-12-15 18:09:54.765	    7f4f86b31700	ERROR	supernode.supernode	home/jgr/src/graft-ng/src/rta/supernode.cpp:352	Failed to refresh supernode wallet: FCJasNxS5eZFMCFDyTUY7f1qA25i31pfF1ToUEdGVydnKZZyeUwmk4PDv5MnnQ28bX3ghrwiToamXRgUuATiDhXWHbNPk8c
Dec 15 14:09:54 keynes graft_server[1320090]: 2018-12-15 18:09:54.765	    7f4f86b31700	ERROR	supernode	home/jgr/src/graft-ng/src/requestdefines.cpp:124	errorCustomError called with failed to refresh supernode: FCJasNxS5eZFMCFDyTUY7f1qA25i31pfF1ToUEdGVydnKZZyeUwmk4PDv5MnnQ28bX3ghrwiToamXRgUuATiDhXWHbNPk8c-32603
Dec 15 14:10:44 keynes graft_server[1320090]: 2018-12-15 18:10:44.801	    7f4f86b31700	ERROR	supernode.sendsupernodeannouncerequest	home/jgr/src/graft-ng/src/requests/sendsupernodeannouncerequest.cpp:165	Failed to send announce
Dec 15 14:18:25 keynes graft_server[1320090]: 2018-12-15 18:18:25.458	    7f4f86b31700	ERROR	supernode.sendsupernodeannouncerequest	home/jgr/src/graft-ng/src/requests/sendsupernodeannouncerequest.cpp:165	Failed to send announce
Dec 15 14:19:15 keynes graft_server[1320090]: 2018-12-15 18:19:15.499	    7f4f87332700	ERROR	net.http	home/jgr/src/GraftNetwork/contrib/epee/include/net/http_client.h:906	HTTP_CLIENT: Failed to SEND
Dec 15 14:19:15 keynes graft_server[1320090]: 2018-12-15 18:19:15.499	    7f4f87332700	ERROR	wallet.wallet2	home/jgr/src/GraftNetwork/src/wallet/wallet2.cpp:1269	!r. THROW EXCEPTION: error::no_connection_to_daemon
Dec 15 14:19:15 keynes graft_server[1320090]: 2018-12-15 18:19:15.499	    7f4f87332700	WARN 	net.http	home/jgr/src/GraftNetwork/src/wallet/wallet_errors.h:724	/home/jgr/src/GraftNetwork/src/wallet/wallet2.cpp:1269:N5tools5error23no_connection_to_daemonE: no connection to daemon, request = getblocks.bin
Dec 15 14:19:15 keynes graft_server[1320090]: 2018-12-15 18:19:15.500	    7f4f87332700	ERROR	supernode.supernode	home/jgr/src/graft-ng/src/rta/supernode.cpp:352	Failed to refresh supernode wallet: FCJasNxS5eZFMCFDyTUY7f1qA25i31pfF1ToUEdGVydnKZZyeUwmk4PDv5MnnQ28bX3ghrwiToamXRgUuATiDhXWHbNPk8c
Dec 15 14:19:15 keynes graft_server[1320090]: 2018-12-15 18:19:15.500	    7f4f87332700	ERROR	supernode	home/jgr/src/graft-ng/src/requestdefines.cpp:124	errorCustomError called with failed to refresh supernode: FCJasNxS5eZFMCFDyTUY7f1qA25i31pfF1ToUEdGVydnKZZyeUwmk4PDv5MnnQ28bX3ghrwiToamXRgUuATiDhXWHbNPk8c-32603
Dec 15 14:20:05 keynes graft_server[1320090]: 2018-12-15 18:20:05.538	    7f4f86b31700	ERROR	supernode.sendsupernodeannouncerequest	home/jgr/src/graft-ng/src/requests/sendsupernodeannouncerequest.cpp:165	Failed to send announce
```