### PR TITLE
HTTP connection pool for libwallet

### DIFF
--- a/src/wallet/CMakeLists.txt
+++ b/src/wallet/CMakeLists.txt
@@ -35,6 +35,7 @@ set(wallet_sources
   graft_wallet.cpp
   wallet_args.cpp
   node_rpc_proxy.cpp
+  http_connection_pool.cpp
   api/wallet.cpp
   api/wallet_manager.cpp
   api/transaction_info.cpp
@@ -57,6 +58,7 @@ set(wallet_private_headers
   wallet_rpc_server_commands_defs.h
   wallet_rpc_server_error_codes.h
   node_rpc_proxy.h
+  http_connection_pool.h
   api/wallet.h
   api/wallet_manager.h
   api/transaction_info.h

--- a/src/wallet/http_connection_pool.cpp
+++ b/src/wallet/http_connection_pool.cpp
@@ -1,0 +1,168 @@
+#include "http_connection_pool.h"
+
+using namespace tools;
+
+const int HTTP_CONNECTION_TIMEOUT_MS = 20000;
+
+namespace tools
+{
+
+/// HttpClientHolder
+class HttpClientHolder
+{
+public:
+  HttpClientHolder(const std::string& host, const std::string& port, boost::optional<epee::net_utils::http::login> user)
+    : m_locked(false)
+  {
+    m_http_client.set_server(host, port, user);
+  }
+
+  epee::net_utils::http::http_simple_client& get_client() { return m_http_client; }
+
+  bool tryLock()
+  {
+    bool expected = false;
+
+    if (!m_locked.compare_exchange_strong(expected, true, std::memory_order::memory_order_seq_cst))
+      return false;
+
+    return true;
+  }
+
+  void unlock()
+  {
+    m_locked.store(false, std::memory_order::memory_order_seq_cst);
+  }
+
+private:
+  std::atomic<bool> m_locked;
+  epee::net_utils::http::http_simple_client m_http_client;
+};
+
+/// HttpConnectionImpl
+class HttpConnectionImpl
+{
+public:
+  HttpConnectionImpl(const std::string& host, const std::string& port, boost::optional<epee::net_utils::http::login> user)
+    : m_host(host)
+    , m_port(port)
+    , m_user(user)
+  {
+  }
+
+  HttpClientHolderPtr get_client_holder()
+  {
+    try
+    {
+      {
+        std::lock_guard<std::mutex> lock(m_clients_mutex);
+
+        for (HttpClientHolderPtr& client : m_clients)
+        {
+          if (client->tryLock())
+            return client;
+        }
+      }
+
+      HttpClientHolderPtr new_client = std::make_shared<HttpClientHolder>(m_host, m_port, m_user);
+
+      bool r = new_client->tryLock();
+
+      assert(r && "tryLock should always succeed for new created clients");
+
+      std::lock_guard<std::mutex> lock(m_clients_mutex);
+
+      m_clients.push_back(new_client);
+
+      return new_client;
+    }
+    catch (...)
+    {
+      return nullptr;
+    }
+  }
+
+private:
+  typedef std::list<HttpClientHolderPtr> HttpClientList;
+
+  std::string m_host;
+  std::string m_port;
+  boost::optional<epee::net_utils::http::login> m_user;
+  std::mutex m_clients_mutex;
+  HttpClientList m_clients;
+};
+
+}
+
+/// HttpInvoker
+HttpInvoker::HttpInvoker(HttpConnection& connection)
+  : m_client_holder(connection.get_client_holder())
+{
+  //already locked by HttpConectionImpl::get_client_holder or null
+}
+
+HttpInvoker::~HttpInvoker()
+{
+  if (m_client_holder)
+    m_client_holder->unlock();
+}
+
+epee::net_utils::http::http_simple_client* HttpInvoker::get_client()
+{
+  if (!m_client_holder)
+    return nullptr;
+
+  return &m_client_holder->get_client();
+}
+
+/// HttpConnection
+
+HttpConnection::HttpConnection(HttpConnectionManager& manager, const std::string& host, const std::string& port, boost::optional<epee::net_utils::http::login> user)
+  : m_impl(manager.get_connection(host, port, user))
+{
+}
+
+HttpClientHolderPtr HttpConnection::get_client_holder()
+{
+  return m_impl->get_client_holder();
+}
+
+/// HttpConnectionManager
+
+HttpConnectionManager::HttpConnectionManager()
+{
+}
+
+HttpConnectionManager::~HttpConnectionManager()
+{
+}
+
+HttpConnectionManager& HttpConnectionManager::get_instance()
+{
+  static HttpConnectionManager instance;
+  return instance;
+}
+
+HttpConnectionImplPtr HttpConnectionManager::get_connection(const std::string& host, const std::string& port, boost::optional<epee::net_utils::http::login> user)
+{
+  std::string key = host + ":" + port;
+
+  if (user)
+  {
+    key += "@";
+    key += user->username;
+  }
+
+  std::lock_guard<std::mutex> lock(m_connections_mutex);
+
+  ConnectionMap::iterator it = m_connections.find(key);
+
+  if (it != m_connections.end())
+    return it->second;
+
+  HttpConnectionImplPtr new_connection = std::make_shared<HttpConnectionImpl>(host, port, user);
+
+  m_connections[key] = new_connection;
+
+  return new_connection;  
+}

--- a/src/wallet/http_connection_pool.cpp
+++ b/src/wallet/http_connection_pool.cpp
@@ -124,6 +124,9 @@ HttpConnection::HttpConnection(HttpConnectionManager& manager, const std::string
 
 HttpClientHolderPtr HttpConnection::get_client_holder()
 {
+  if (!m_impl)
+    return HttpClientHolderPtr();
+
   return m_impl->get_client_holder();
 }
 

--- a/src/wallet/http_connection_pool.h
+++ b/src/wallet/http_connection_pool.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include "net/http_client.h"
+
+#include <memory>
+#include <unordered_map>
+
+namespace tools
+{
+
+//forwards
+class HttpConnectionImpl;
+class HttpClientHolder;
+
+typedef std::shared_ptr<HttpConnectionImpl> HttpConnectionImplPtr;
+typedef std::shared_ptr<HttpClientHolder> HttpClientHolderPtr;
+
+class HttpConnectionManager
+{
+public:
+  HttpConnectionManager();
+  ~HttpConnectionManager();
+
+  HttpConnectionManager(const HttpConnectionManager&) = delete;
+  HttpConnectionManager(HttpConnectionManager&&) = delete;
+  HttpConnectionManager& operator = (const HttpConnectionManager&) = delete;
+
+  HttpConnectionImplPtr get_connection(const std::string& host, const std::string& port, boost::optional<epee::net_utils::http::login> user);
+
+  static HttpConnectionManager& get_instance();
+
+private:
+  typedef std::unordered_map<std::string, HttpConnectionImplPtr> ConnectionMap;
+
+  std::mutex m_connections_mutex;
+  ConnectionMap m_connections;
+};
+
+class HttpConnection
+{
+public:
+  HttpConnection() = default;
+  HttpConnection(HttpConnectionManager& manager, const std::string& host, const std::string& port, boost::optional<epee::net_utils::http::login> user);
+  ~HttpConnection() = default;
+
+  HttpClientHolderPtr get_client_holder();
+
+private:
+  HttpConnectionImplPtr m_impl;
+};
+
+class HttpInvoker
+{
+public:
+  HttpInvoker(HttpConnection&);
+  ~HttpInvoker();
+
+  HttpInvoker(const HttpInvoker&) = delete;
+  HttpInvoker(HttpInvoker&&) = delete;
+  HttpInvoker& operator = (const HttpInvoker&) = delete;
+
+  epee::net_utils::http::http_simple_client* get_client();
+
+private:
+  HttpClientHolderPtr m_client_holder;
+};
+
+template<class t_request, class t_response>
+bool invoke_http_json
+ (const boost::string_ref uri,
+  const t_request& out_struct,
+  t_response& result_struct,
+  HttpConnection& connection,
+  std::chrono::milliseconds timeout = std::chrono::seconds(15),
+  const boost::string_ref method = "GET")
+{
+  HttpInvoker invoker(connection);
+  epee::net_utils::http::http_simple_client* http_client = invoker.get_client();
+
+  if (!http_client)
+    return false;
+
+  return invoke_http_json(uri, out_struct, result_struct, *http_client, timeout, method);
+}
+
+template<class t_request, class t_response>
+bool invoke_http_bin
+ (const boost::string_ref uri,
+  const t_request& out_struct,
+  t_response& result_struct,
+  HttpConnection& connection,
+  std::chrono::milliseconds timeout = std::chrono::seconds(15),
+  const boost::string_ref method = "GET")
+{
+  HttpInvoker invoker(connection);
+  epee::net_utils::http::http_simple_client* http_client = invoker.get_client();
+
+  if (!http_client)
+    return false;
+
+  return invoke_http_bin(uri, out_struct, result_struct, *http_client, timeout, method);
+}
+
+}

--- a/src/wallet/node_rpc_proxy.cpp
+++ b/src/wallet/node_rpc_proxy.cpp
@@ -38,8 +38,8 @@ namespace tools
 
 static const std::chrono::seconds rpc_timeout = std::chrono::minutes(3) + std::chrono::seconds(30);
 
-NodeRPCProxy::NodeRPCProxy(epee::net_utils::http::http_simple_client &http_client, boost::mutex &mutex)
-  : m_http_client(http_client)
+NodeRPCProxy::NodeRPCProxy(HttpConnection &http_connection, boost::mutex &mutex)
+  : m_http_connection(http_connection)
   , m_daemon_rpc_mutex(mutex)
   , m_height(0)
   , m_height_time(0)
@@ -77,7 +77,7 @@ boost::optional<std::string> NodeRPCProxy::get_rpc_version(uint32_t &rpc_version
     req_t.id = epee::serialization::storage_entry(0);
     req_t.method = "get_version";
     m_daemon_rpc_mutex.lock();
-    bool r = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client, rpc_timeout);
+    bool r = invoke_http_json("/json_rpc", req_t, resp_t, m_http_connection, rpc_timeout);
     m_daemon_rpc_mutex.unlock();
     CHECK_AND_ASSERT_MES(r, std::string(), "Failed to connect to daemon");
     CHECK_AND_ASSERT_MES(resp_t.result.status != CORE_RPC_STATUS_BUSY, resp_t.result.status, "Failed to connect to daemon");
@@ -97,7 +97,7 @@ boost::optional<std::string> NodeRPCProxy::get_height(uint64_t &height) const
     cryptonote::COMMAND_RPC_GET_HEIGHT::response res = AUTO_VAL_INIT(res);
 
     m_daemon_rpc_mutex.lock();
-    bool r = net_utils::invoke_http_json("/getheight", req, res, m_http_client, rpc_timeout);
+    bool r = invoke_http_json("/getheight", req, res, m_http_connection, rpc_timeout);
     m_daemon_rpc_mutex.unlock();
     CHECK_AND_ASSERT_MES(r, std::string(), "Failed to connect to daemon");
     CHECK_AND_ASSERT_MES(res.status != CORE_RPC_STATUS_BUSY, res.status, "Failed to connect to daemon");
@@ -126,7 +126,7 @@ boost::optional<std::string> NodeRPCProxy::get_target_height(uint64_t &height) c
     req_t.id = epee::serialization::storage_entry(0);
     req_t.method = "get_info";
     m_daemon_rpc_mutex.lock();
-    bool r = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client, rpc_timeout);
+    bool r = invoke_http_json("/json_rpc", req_t, resp_t, m_http_connection, rpc_timeout);
     m_daemon_rpc_mutex.unlock();
 
     CHECK_AND_ASSERT_MES(r, std::string(), "Failed to connect to daemon");
@@ -151,7 +151,7 @@ boost::optional<std::string> NodeRPCProxy::get_earliest_height(uint8_t version, 
     req_t.id = epee::serialization::storage_entry(0);
     req_t.method = "hard_fork_info";
     req_t.params.version = version;
-    bool r = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client, rpc_timeout);
+    bool r = invoke_http_json("/json_rpc", req_t, resp_t, m_http_connection, rpc_timeout);
     m_daemon_rpc_mutex.unlock();
     CHECK_AND_ASSERT_MES(r, std::string(), "Failed to connect to daemon");
     CHECK_AND_ASSERT_MES(resp_t.result.status != CORE_RPC_STATUS_BUSY, resp_t.result.status, "Failed to connect to daemon");
@@ -181,7 +181,7 @@ boost::optional<std::string> NodeRPCProxy::get_dynamic_per_kb_fee_estimate(uint6
     req_t.id = epee::serialization::storage_entry(0);
     req_t.method = "get_fee_estimate";
     req_t.params.grace_blocks = grace_blocks;
-    bool r = net_utils::invoke_http_json("/json_rpc", req_t, resp_t, m_http_client, rpc_timeout);
+    bool r = invoke_http_json("/json_rpc", req_t, resp_t, m_http_connection, rpc_timeout);
     m_daemon_rpc_mutex.unlock();
     CHECK_AND_ASSERT_MES(r, std::string(), "Failed to connect to daemon");
     CHECK_AND_ASSERT_MES(resp_t.result.status != CORE_RPC_STATUS_BUSY, resp_t.result.status, "Failed to connect to daemon");

--- a/src/wallet/node_rpc_proxy.h
+++ b/src/wallet/node_rpc_proxy.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <boost/thread/mutex.hpp>
+#include "http_connection_pool.h"
 #include "include_base_utils.h"
 #include "net/http_client.h"
 
@@ -39,7 +40,7 @@ namespace tools
 class NodeRPCProxy
 {
 public:
-  NodeRPCProxy(epee::net_utils::http::http_simple_client &http_client, boost::mutex &mutex);
+  NodeRPCProxy(HttpConnection &connection, boost::mutex &mutex);
 
   void invalidate();
 
@@ -51,7 +52,7 @@ public:
   boost::optional<std::string> get_dynamic_per_kb_fee_estimate(uint64_t grace_blocks, uint64_t &fee) const;
 
 private:
-  epee::net_utils::http::http_simple_client &m_http_client;
+  HttpConnection &m_http_connection;
   boost::mutex &m_daemon_rpc_mutex;
 
   mutable uint64_t m_height;

--- a/src/wallet/wallet2.h
+++ b/src/wallet/wallet2.h
@@ -38,6 +38,7 @@
 #include <boost/serialization/vector.hpp>
 #include <atomic>
 
+#include "http_connection_pool.h"
 #include "include_base_utils.h"
 #include "cryptonote_basic/account.h"
 #include "cryptonote_basic/account_boost_serialization.h"
@@ -105,7 +106,7 @@ namespace tools
     };
 
   private:
-    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false),m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
+    wallet2(const wallet2&) : m_run(true), m_callback(0), m_testnet(false), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false), m_node_rpc_proxy(m_http_connection, m_daemon_rpc_mutex) {}
 
   public:
     static const char* tr(const char* str);
@@ -131,7 +132,7 @@ namespace tools
 
     static bool verify_password(const std::string& keys_file_name, const std::string& password, bool watch_only);
 
-    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false), m_restricted(restricted), is_old_file_format(false), m_node_rpc_proxy(m_http_client, m_daemon_rpc_mutex) {}
+    wallet2(bool testnet = false, bool restricted = false) : m_run(true), m_callback(0), m_testnet(testnet), m_always_confirm_transfers(true), m_print_ring_members(false), m_store_tx_info(true), m_default_mixin(0), m_default_priority(0), m_refresh_type(RefreshOptimizeCoinbase), m_auto_refresh(true), m_refresh_from_block_height(0), m_confirm_missing_payment_id(true), m_ask_password(true), m_min_output_count(0), m_min_output_value(0), m_merge_destinations(false), m_confirm_backlog(true), m_is_initialized(false), m_restricted(restricted), is_old_file_format(false), m_node_rpc_proxy(m_http_connection, m_daemon_rpc_mutex) {}
 
     struct transfer_details
     {
@@ -714,7 +715,7 @@ namespace tools
     std::string m_daemon_address;
     std::string m_wallet_file;
     std::string m_keys_file;
-    epee::net_utils::http::http_simple_client m_http_client;
+    HttpConnection m_http_connection;
     std::vector<crypto::hash> m_blockchain;
     std::atomic<uint64_t> m_local_bc_height; //temporary workaround
     std::unordered_map<crypto::hash, unconfirmed_transfer_details> m_unconfirmed_txs;
@@ -1127,7 +1128,7 @@ namespace tools
       }
 
       m_daemon_rpc_mutex.lock();
-      bool r = epee::net_utils::invoke_http_bin("/getrandom_outs.bin", req, daemon_resp, m_http_client, rpc_timeout);
+      bool r = invoke_http_bin("/getrandom_outs.bin", req, daemon_resp, m_http_connection, rpc_timeout);
       m_daemon_rpc_mutex.unlock();
       THROW_WALLET_EXCEPTION_IF(!r, error::no_connection_to_daemon, "getrandom_outs.bin");
       THROW_WALLET_EXCEPTION_IF(daemon_resp.status == CORE_RPC_STATUS_BUSY, error::daemon_busy, "getrandom_outs.bin");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,6 +92,7 @@ add_subdirectory(difficulty)
 add_subdirectory(hash)
 add_subdirectory(net_load_tests)
 add_subdirectory(libwallet_api_tests)
+add_subdirectory(libwallet_performance_tests)
 add_subdirectory(supernode_tests)
 
 # add_subdirectory(daemon_tests)

--- a/tests/libwallet_performance_tests/CMakeLists.txt
+++ b/tests/libwallet_performance_tests/CMakeLists.txt
@@ -1,0 +1,33 @@
+set(libwallet_performance_tests_sources
+  main.cpp
+)
+
+set(libwallet_performance_tests_headers
+  )
+
+add_executable(libwallet_performance_tests
+  ${libwallet_performance_tests_sources}
+  ${libwallet_performance_tests_headers})
+
+target_link_libraries(libwallet_performance_tests
+  PRIVATE
+    wallet
+    epee
+    ${GTEST_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${EXTRA_LIBRARIES})
+
+set_property(TARGET libwallet_performance_tests
+  PROPERTY
+    FOLDER "tests")
+
+if (NOT MSVC)
+  set_property(TARGET libwallet_performance_tests
+    APPEND_STRING
+    PROPERTY
+      COMPILE_FLAGS " -Wno-undef -Wno-sign-compare")
+endif ()
+
+add_test(
+  NAME    libwallet_performance_tests
+  COMMAND libwallet_performance_tests)

--- a/tests/libwallet_performance_tests/main.cpp
+++ b/tests/libwallet_performance_tests/main.cpp
@@ -1,17 +1,78 @@
 #include "gtest/gtest.h"
 
-#include "wallet/wallet2.h"
+#include "wallet/graft_wallet.h"
 
-#include <thread>
 #include <atomic>
+#include <memory>
+#include <thread>
+#include <cstdio>
+
+using namespace tools;
+
+namespace
+{
+
+const std::string TESTNET_DAEMON_ADDRESS = "localhost:" + std::to_string(config::testnet::RPC_DEFAULT_PORT);
+
+void wallet_worker(std::atomic<int>& wallets_counter, int total_wallets_count)
+{
+  std::list<std::shared_ptr<wallet2>> wallets;
+
+  for (;;)
+  {
+    int wallet_index = ++wallets_counter;
+
+    if (total_wallets_count < wallet_index)
+      break;
+
+    try
+    {
+      const bool testnet = true;
+
+      std::shared_ptr<GraftWallet> wallet = std::make_shared<GraftWallet>(testnet);
+
+      wallet->init(TESTNET_DAEMON_ADDRESS, boost::optional<epee::net_utils::http::login>(), 0);
+      wallet->set_seed_language("English");
+    
+      crypto::secret_key secret_key = wallet->generateFromData("");
+
+      wallet->refresh();
+
+      wallets.emplace_back(std::move(wallet));
+
+      printf("Wallet #%d has been created\n", wallet_index);
+      fflush(stdout);
+    }
+    catch (std::exception& e)
+    {
+      FAIL() << e.what();
+    }
+  }
+}
+
+}
 
 TEST(WalletPerformanceTest, HttpConnectionPool)
 {
+  const int total_wallets_count = 10;
+  const int threads_count = 2;
 
+  std::vector<std::thread> threads;
+  std::atomic<int> wallets_counter(0);
+
+  for (int i=0; i<threads_count; i++)
+    threads.emplace_back([&]{ wallet_worker(wallets_counter, total_wallets_count); });
+
+  for (std::thread& thread : threads)
+    if (thread.joinable())
+      thread.join();
 }
 
 int main(int argc, char** argv)
 {
+  mlog_configure("", true);
+  mlog_set_log_level(1);
+
   ::testing::InitGoogleTest(&argc, argv);
 
   return RUN_ALL_TESTS();

--- a/tests/libwallet_performance_tests/main.cpp
+++ b/tests/libwallet_performance_tests/main.cpp
@@ -1,0 +1,18 @@
+#include "gtest/gtest.h"
+
+#include "wallet/wallet2.h"
+
+#include <thread>
+#include <atomic>
+
+TEST(WalletPerformanceTest, HttpConnectionPool)
+{
+
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
This PR provides possibility to use single HTTP connection for requests to the same RPC host/port/user from different wallets. As a result this PR decreases number of outgoing HTTP connections from wallet to daemon.