### PR TITLE
Fix compilation under gcc8

### DIFF
--- a/src/serialization/binary_archive.h
+++ b/src/serialization/binary_archive.h
@@ -99,7 +99,7 @@ struct binary_archive<false> : public binary_archive_base<std::istream, false>
 {
 
   explicit binary_archive(stream_type &s) : base_type(s) {
-    stream_type::streampos pos = stream_.tellg();
+    auto pos = stream_.tellg();
     stream_.seekg(0, std::ios_base::end);
     eof_pos_ = stream_.tellg();
     stream_.seekg(pos);


### PR DESCRIPTION
Fixes compilation error:

```
.../src/serialization/binary_archive.h:102:18: error: ‘streampos’ is not a member of ‘binary_archive_base<std::basic_istream<char>, false>::stream_type’ {aka ‘std::basic_istream<char>’}
     stream_type::streampos pos = stream_.tellg();
                  ^~~~~~~~~
```