### PR TITLE
Fix compilation under C++11 compilers

### DIFF
--- a/src/utils/cryptmsg.cpp
+++ b/src/utils/cryptmsg.cpp
@@ -33,7 +33,7 @@
 
 namespace {
 
-static_assert(201103L <= __cplusplus);
+static_assert(201103L <= __cplusplus, "C++11 compiler required");
 
 #if 0
 //can be used to check manually
@@ -100,7 +100,7 @@ struct CryptoMessageHead
 uint32_t getBhash(const crypto::public_key& B)
 {
     uint32_t res = 0;
-    static_assert(sizeof(B) % sizeof(res) == 0);
+    static_assert(sizeof(B) % sizeof(res) == 0, "public key size must be a multiple of 4");
     const uint32_t* p = reinterpret_cast<const uint32_t*>(&B);
     for(int i = 0, cnt = sizeof(B) / sizeof(res); i < cnt; ++i, ++p)
     {
@@ -239,7 +239,7 @@ size_t decryptMsg(size_t inputSize, const uint8_t* input, const crypto::secret_k
 
 } //namespace
 
-namespace graft::crypto_tools {
+namespace graft { namespace crypto_tools {
 
 void encryptMessage(const std::string& input, const std::vector<crypto::public_key>& Bkeys, std::string& output)
 {
@@ -284,5 +284,5 @@ bool decryptMessage(const std::string& input, const crypto::secret_key& bkey, st
     return true;
 }
 
-} //namespace graft::crypto_tools
+}} //namespace graft::crypto_tools
 

--- a/src/utils/cryptmsg.h
+++ b/src/utils/cryptmsg.h
@@ -32,7 +32,7 @@
 #include "crypto/crypto.h"
 #include <vector>
 
-namespace graft::crypto_tools {
+namespace graft { namespace crypto_tools {
 
 /*!
  * \brief encryptMessage - encrypts data for recipients using their B public keys (assumed public view keys).
@@ -62,4 +62,4 @@ void encryptMessage(const std::string& input, const crypto::public_key& Bkey, st
  */
 bool decryptMessage(const std::string& input, const crypto::secret_key& bkey, std::string& output);
 
-} //namespace graft::crypto_tools
+}} //namespace graft::crypto_tools


### PR DESCRIPTION
Fix compilation under systems with older compilers (like Ubutnu 16.04).

One of these checks is particularly strange: it checks for a C++11 compiler using a one-argument `static_assert` only added in C++14.

The other is to remove nested namespace declarations, which is a C++17 feature.