### PR TITLE
Ubuntu 16 build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,14 @@ endif()
 
 add_definitions(-DMONERO_DEFAULT_LOG_CATEGORY="cryptonode" -DCMAKE_ROOT_SOURCE_DIR="${CMAKE_ROOT_SOURCE_DIR}")
 
+if(NOT DEFINED ENABLE_TLS_LOG_CATEGORY)
+    option(ENABLE_TLS_LOG_CATEGORY "Enable TLS-based logging." OFF)
+endif()
+
+if(ENABLE_TLS_LOG_CATEGORY)
+    add_definitions(-DENABLE_TLS_LOG_CATEGORY)
+endif()
+
 if(NOT DEFINED ENABLE_SYSLOG)
     option(ENABLE_SYSLOG "SYSLOG support. It can be compiled for UNIX-like platforms only." OFF)
 endif()

--- a/contrib/epee/include/misc_log_ex.h
+++ b/contrib/epee/include/misc_log_ex.h
@@ -55,6 +55,7 @@
 #define MONERO_DEFAULT_LOG_CATEGORY "default"
 #endif
 
+#ifdef ENABLE_TLS_LOG_CATEGORY
 #ifdef __cplusplus
 #if __cplusplus >= 201103L
 
@@ -69,6 +70,7 @@ extern thread_local std::string mlog_current_log_category;
 
 #endif //__cplusplus >= 201103L
 #endif //__cplusplus
+#endif //ENABLE_TLS_LOG_CATEGORY
 
 #ifndef MONERO_LOG_CATEGORY
 #define MONERO_LOG_CATEGORY MONERO_DEFAULT_LOG_CATEGORY

--- a/contrib/epee/src/mlog.cpp
+++ b/contrib/epee/src/mlog.cpp
@@ -39,7 +39,9 @@
 
 #define MLOG_LOG(x) CINFO(el::base::Writer,el::base::DispatchAction::FileOnlyLog,MONERO_DEFAULT_LOG_CATEGORY) << x
 
+#ifdef ENABLE_TLS_LOG_CATEGORY
 thread_local std::string mlog_current_log_category;
+#endif
 
 bool mlog_syslog = false;
 


### PR DESCRIPTION
ENABLE_TLS_LOG_CATEGORY option added. OFF by default. When OFF it enables build on Ubuntu 16