### PR TITLE
Blockchain based list fixes

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -4194,6 +4194,11 @@ bool Blockchain::get_hard_fork_voting_info(uint8_t version, uint32_t &window, ui
   return m_hardfork->get_voting_info(version, window, votes, threshold, earliest_height, voting);
 }
 
+uint64_t Blockchain::get_earliest_ideal_height_for_version(uint8_t version) const
+{
+  return m_hardfork->get_earliest_ideal_height_for_version(version);
+}
+
 std::map<uint64_t, std::tuple<uint64_t, uint64_t, uint64_t>> Blockchain:: get_output_histogram(const std::vector<uint64_t> &amounts, bool unlocked, uint64_t recent_cutoff) const
 {
   return m_db->get_output_histogram(amounts, unlocked, recent_cutoff);

--- a/src/cryptonote_core/blockchain.h
+++ b/src/cryptonote_core/blockchain.h
@@ -775,6 +775,11 @@ namespace cryptonote
     bool get_hard_fork_voting_info(uint8_t version, uint32_t &window, uint32_t &votes, uint32_t &threshold, uint64_t &earliest_height, uint8_t &voting) const;
 
     /**
+     * @brief returns the earliest block a given version may activate
+     */
+    uint64_t get_earliest_ideal_height_for_version(uint8_t version) const;
+
+    /**
      * @brief remove transactions from the transaction pool (if present)
      *
      * @param txids a list of hashes of transactions to be removed

--- a/src/cryptonote_core/blockchain_based_list.cpp
+++ b/src/cryptonote_core/blockchain_based_list.cpp
@@ -47,8 +47,8 @@ bool is_valid_stake(uint64_t block_height, uint64_t stake_block_height, uint64_t
   if (block_height < stake_block_height)
     return false; //stake transaction block is in future
 
-  uint64_t stake_first_valid_block = stake_block_height + config::graft::STAKE_VALIDATION_PERIOD,
-           stake_last_valid_block  = stake_block_height + stake_unlock_time + config::graft::TRUSTED_RESTAKING_PERIOD;
+  uint64_t stake_first_valid_block = stake_block_height,
+           stake_last_valid_block  = stake_block_height + stake_unlock_time;
 
   if (stake_last_valid_block <= block_height)
     return false; //stake transaction is not valid

--- a/src/cryptonote_core/blockchain_based_list.cpp
+++ b/src/cryptonote_core/blockchain_based_list.cpp
@@ -15,10 +15,11 @@ const size_t BLOCKCHAIN_BASED_LISTS_HISTORY_DEPTH   = 1000;
 
 }
 
-BlockchainBasedList::BlockchainBasedList(const std::string& m_storage_file_name)
+BlockchainBasedList::BlockchainBasedList(const std::string& m_storage_file_name, uint64_t first_block_number)
   : m_storage_file_name(m_storage_file_name)
-  , m_block_height()
+  , m_block_height(first_block_number)
   , m_history_depth()
+  , m_first_block_number(first_block_number)
   , m_need_store()
 {
   load();
@@ -186,7 +187,7 @@ void BlockchainBasedList::apply_block(uint64_t block_height, const crypto::hash&
 
 void BlockchainBasedList::remove_latest_block()
 {
-  if (!m_block_height)
+  if (!m_history_depth)
     return;
 
   m_need_store = true;
@@ -197,7 +198,7 @@ void BlockchainBasedList::remove_latest_block()
   m_history.pop_back();
 
   if (m_history.empty())
-    m_block_height = 0;
+    m_block_height = m_first_block_number;
 }
 
 namespace

--- a/src/cryptonote_core/blockchain_based_list.h
+++ b/src/cryptonote_core/blockchain_based_list.h
@@ -33,7 +33,7 @@ public:
   typedef std::list<supernode_tier_array>  list_history;
 
   /// Constructors
-  BlockchainBasedList(const std::string& file_name);
+  BlockchainBasedList(const std::string& file_name, uint64_t first_block_number);
 
   /// List of tiers
   const supernode_tier_array& tiers(size_t depth = 0) const;
@@ -69,6 +69,7 @@ private:
   uint64_t m_block_height;
   size_t m_history_depth;
   std::mt19937_64 m_rng;
+  uint64_t m_first_block_number;
   mutable bool m_need_store;
 };
 

--- a/src/cryptonote_core/stake_transaction_processor.cpp
+++ b/src/cryptonote_core/stake_transaction_processor.cpp
@@ -9,7 +9,7 @@ namespace
 {
 
 const char* STAKE_TRANSACTION_STORAGE_FILE_NAME = "stake_transactions.v2.bin";
-const char* BLOCKCHAIN_BASED_LIST_FILE_NAME     = "blockchain_based_list.v4.bin";
+const char* BLOCKCHAIN_BASED_LIST_FILE_NAME     = "blockchain_based_list.v5.bin";
 
 }
 

--- a/src/cryptonote_core/stake_transaction_processor.h
+++ b/src/cryptonote_core/stake_transaction_processor.h
@@ -44,6 +44,7 @@ public:
   void invoke_update_blockchain_based_list_handler(bool force = true, size_t depth = 1);
 
 private:
+  void init_storages_impl();
   void process_block(uint64_t block_index, const block& block, const crypto::hash& block_hash, bool update_storage = true);
   void invoke_update_stakes_handler_impl(uint64_t block_index);
   void invoke_update_blockchain_based_list_handler_impl(size_t depth);
@@ -51,6 +52,7 @@ private:
   void process_block_blockchain_based_list(uint64_t block_index, const block& block, const crypto::hash& block_hash, bool update_storage = true);
 
 private:
+  std::string m_config_dir;
   Blockchain& m_blockchain;
   std::unique_ptr<StakeTransactionStorage> m_storage;
   std::unique_ptr<BlockchainBasedList> m_blockchain_based_list;

--- a/src/cryptonote_core/stake_transaction_storage.cpp
+++ b/src/cryptonote_core/stake_transaction_storage.cpp
@@ -187,8 +187,8 @@ void StakeTransactionStorage::update_supernode_stakes(uint64_t block_number)
         {
           new_stake.amount       = tx.amount;
           new_stake.tier         = get_tier(new_stake.amount);
-          new_stake.block_height = tx.block_height;
-          new_stake.unlock_time  = tx.unlock_time;
+          new_stake.block_height = tx.block_height + config::graft::STAKE_VALIDATION_PERIOD;
+          new_stake.unlock_time  = tx.unlock_time + config::graft::TRUSTED_RESTAKING_PERIOD - config::graft::STAKE_VALIDATION_PERIOD;
         }
 
         new_stake.supernode_public_id      = tx.supernode_public_id;
@@ -214,8 +214,8 @@ void StakeTransactionStorage::update_supernode_stakes(uint64_t block_number)
 
         stake.amount       = tx.amount;
         stake.tier         = get_tier(stake.amount);
-        stake.block_height = tx.block_height;
-        stake.unlock_time  = tx.unlock_time;
+        stake.block_height = tx.block_height + config::graft::STAKE_VALIDATION_PERIOD;
+        stake.unlock_time  = tx.unlock_time + config::graft::TRUSTED_RESTAKING_PERIOD - config::graft::STAKE_VALIDATION_PERIOD;
 
         continue;
       }

--- a/src/cryptonote_core/stake_transaction_storage.h
+++ b/src/cryptonote_core/stake_transaction_storage.h
@@ -53,7 +53,7 @@ public:
   typedef std::list<crypto::hash>        block_hash_list;
   typedef std::vector<supernode_stake>   supernode_stake_array;
 
-  StakeTransactionStorage(const std::string& storage_file_name);
+  StakeTransactionStorage(const std::string& storage_file_name, uint64_t first_block_number);
 
   /// Get number of transactions
   size_t get_tx_count() const { return m_stake_txs.size(); }
@@ -66,6 +66,9 @@ public:
   
   /// Get array of last block hashes
   const crypto::hash& get_last_processed_block_hash() const;
+
+  /// Has last processed blocks
+  bool has_last_processed_block() const { return m_last_processed_block_hashes_count > 0; }
 
   /// Add new processed block
   void add_last_processed_block(uint64_t index, const crypto::hash& hash);
@@ -109,6 +112,7 @@ private:
   uint64_t m_supernode_stakes_update_block_number;
   supernode_stake_array m_supernode_stakes;
   supernode_stake_index_map m_supernode_stake_indexes;
+  uint64_t m_first_block_number;
   mutable bool m_need_store;
 };
 


### PR DESCRIPTION
This PR contains following fixes:
- fix for blockchain based list building; supernodes from previous list are used with new stakes and can be moved to another tier; this resolves an issue with duplication of supernodes in several different tiers;
- scanning of blockchain is started from hardfork block, not from the beginning;
- synchronization with blockchain during the start of cryptonode reworked to make several iterations instead of full scanning;
- stake validation period changed; now it shows validity after STAKE_VALIDATION_PERIOD and including TRUSTED_RESTAKING_PERIOD.