### PR TITLE
Fix Windows compile for libboost-1.69

### DIFF
--- a/src/cryptonote_basic/miner.cpp
+++ b/src/cryptonote_basic/miner.cpp
@@ -619,7 +619,7 @@ namespace cryptonote
       }
       else
       {
-        on_ac_power = !battery_powered;
+        on_ac_power = !(bool)battery_powered;
       }
 
       if( m_is_background_mining_started )


### PR DESCRIPTION
Fix issue when compiling with `libboost-1.69.0-2` for Windows MSYS builds.

Same fix is applied here:

https://github.com/LetheanMovement/lethean/commit/82a4d18de334cd4f670c5adb1cccd4d62a94d0cf

Otherwise it fails with the following error:
```
C:/msys64/home/ku4eto/GraftNetwork/src/cryptonote_basic/miner.cpp:622:24: error: cannot convert 'boost::logic::tribool' to 'bool' in assignment
         on_ac_power = !battery_powered;
```