### PR TITLE
fixed shared-ringdb location

### DIFF
--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -134,6 +134,9 @@ static bool parse_db_sync_mode(std::string db_sync_mode)
 static std::string get_default_db_path()
 {
   boost::filesystem::path dir = tools::get_default_data_dir();
+  // remove .bitmonero, replace with .shared-ringdb
+  dir = dir.remove_filename();
+  dir /= ".shared-ringdb";
   return dir.string();
 }
 

--- a/src/blockchain_utilities/blockchain_blackball.cpp
+++ b/src/blockchain_utilities/blockchain_blackball.cpp
@@ -136,7 +136,7 @@ static std::string get_default_db_path()
   boost::filesystem::path dir = tools::get_default_data_dir();
   // remove .bitmonero, replace with .shared-ringdb
   dir = dir.remove_filename();
-  dir /= ".shared-ringdb";
+  dir /= ".graft-shared-ringdb";
   return dir.string();
 }
 

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -74,6 +74,9 @@ namespace {
     std::string get_default_ringdb_path(cryptonote::network_type nettype)
     {
       boost::filesystem::path dir = tools::get_default_data_dir();
+      // remove .bitmonero, replace with .shared-ringdb
+      dir = dir.remove_filename();
+      dir /= ".shared-ringdb";
       if (nettype == cryptonote::TESTNET)
         dir /= "testnet";
       else if (nettype == cryptonote::STAGENET)

--- a/src/wallet/api/wallet.cpp
+++ b/src/wallet/api/wallet.cpp
@@ -76,7 +76,7 @@ namespace {
       boost::filesystem::path dir = tools::get_default_data_dir();
       // remove .bitmonero, replace with .shared-ringdb
       dir = dir.remove_filename();
-      dir /= ".shared-ringdb";
+      dir /= ".graft-shared-ringdb";
       if (nettype == cryptonote::TESTNET)
         dir /= "testnet";
       else if (nettype == cryptonote::STAGENET)

--- a/src/wallet/graft_wallet.cpp
+++ b/src/wallet/graft_wallet.cpp
@@ -22,7 +22,7 @@ namespace
     boost::filesystem::path dir = tools::get_default_data_dir();
     // remove .bitmonero, replace with .shared-ringdb
     dir = dir.remove_filename();
-    dir /= ".shared-ringdb";
+    dir /= ".graft-shared-ringdb";
     switch (nettype) {
     case cryptonote::TESTNET:
         return (boost::filesystem::path(dir.string()) / "testnet").string();

--- a/src/wallet/graft_wallet.cpp
+++ b/src/wallet/graft_wallet.cpp
@@ -20,6 +20,9 @@ namespace
   std::string get_default_db_path(cryptonote::network_type nettype)
   {
     boost::filesystem::path dir = tools::get_default_data_dir();
+    // remove .bitmonero, replace with .shared-ringdb
+    dir = dir.remove_filename();
+    dir /= ".shared-ringdb";
     switch (nettype) {
     case cryptonote::TESTNET:
         return (boost::filesystem::path(dir.string()) / "testnet").string();

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -136,6 +136,9 @@ namespace
   std::string get_default_ringdb_path()
   {
     boost::filesystem::path dir = tools::get_default_data_dir();
+    // remove .bitmonero, replace with .shared-ringdb
+    dir = dir.remove_filename();
+    dir /= ".graft";
     return dir.string();
   }
 

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -138,7 +138,7 @@ namespace
     boost::filesystem::path dir = tools::get_default_data_dir();
     // remove .bitmonero, replace with .shared-ringdb
     dir = dir.remove_filename();
-    dir /= ".graft";
+    dir /= ".graft-shared-ringdb";
     return dir.string();
   }
 


### PR DESCRIPTION
without this fix lmdb files will be created in `.graft/[testnet]` and graftnoded wont start because of extra lmdb files