### PR TITLE
UNTESTED: cmake: Fix "classic" (Kernighan and Ritchie) C main() declaration in CheckLinkerFlag.c

### DIFF
--- a/cmake/CheckLinkerFlag.c
+++ b/cmake/CheckLinkerFlag.c
@@ -1,8 +1,8 @@
 #ifdef __CLASSIC_C__
-int main()
-{
+int main(ac, av)
   int ac;
   char* av[];
+{
 #else
 int main(int ac, char* av[])
 {


### PR DESCRIPTION
UNTESTED: cmake: Fix "classic" (Kernighan and Ritchie) C main() declaration in CheckLinkerFlag.c

[Thanks to Dan Itkis for pointing me to this code a few months ago, although I just started looking at it a day or so ago.  Please don't blame him for my submitting this change probably prematurely.  I did not mention this to him.]

It looks like the code snippet in question was declaring two local stack variables when it was intended to declare two parameters for main (argc and argv, or, rather ac and av in its naming convention).  This change should fix that.

This is an untested change, because I have just started looking at the code, and was just pointed to cmake/CheckLinkerFlag.c by cppcheck, and I am not quite sure how I would about asking cmake to assume that it needed Kernighan & Ritchie style function declarations, and I have just started looking at this code and have not yet even resolved some git submodule complaints when I tried to run cmake on this project.  Normally, I might wait until I had made a bit more progress in my ability to test a change before submitting it, but, in this case, I think that it is a change that I will not easily be able to test anyhow (aside from trying to compile the part of the code that I changed, which I did).

Also, please feel free to redirect me to some upstream source of this file (as I am surprised that anyone would run cryptocurrency code on a pre-ANSI C compiler), or tell me to follow some other process for submitting this patch.

Thanks in advance for considering this proposed patch submission.