### PR TITLE
Adds staking ability to transfer_split RPC, Don't provide RTA-related…

### DIFF
--- a/src/rpc/core_rpc_server.h
+++ b/src/rpc/core_rpc_server.h
@@ -155,15 +155,15 @@ namespace cryptonote
       END_JSON_RPC_MAP()
       // Graft RTA handlers start here
       BEGIN_JSON_RPC_MAP("/json_rpc/rta")
-        MAP_JON_RPC_WE("send_supernode_announce",on_supernode_announce,         COMMAND_RPC_SUPERNODE_ANNOUNCE)
-        MAP_JON_RPC_WE("broadcast",              on_broadcast,                  COMMAND_RPC_BROADCAST)
-        MAP_JON_RPC_WE("multicast",              on_multicast,                  COMMAND_RPC_MULTICAST)
-        MAP_JON_RPC_WE("unicast",                on_unicast,                    COMMAND_RPC_UNICAST)
+        MAP_JON_RPC_WE_IF("send_supernode_announce",on_supernode_announce,         COMMAND_RPC_SUPERNODE_ANNOUNCE, !m_restricted)
+        MAP_JON_RPC_WE_IF("broadcast",              on_broadcast,                  COMMAND_RPC_BROADCAST, !m_restricted)
+        MAP_JON_RPC_WE_IF("multicast",              on_multicast,                  COMMAND_RPC_MULTICAST, !m_restricted)
+        MAP_JON_RPC_WE_IF("unicast",                on_unicast,                    COMMAND_RPC_UNICAST, !m_restricted)
 
-        MAP_JON_RPC_WE("get_tunnels",              on_get_tunnels,              COMMAND_RPC_TUNNEL_DATA)
-        MAP_JON_RPC_WE("send_supernode_stakes",    on_supernode_stakes,         COMMAND_RPC_SUPERNODE_GET_STAKES)
-        MAP_JON_RPC_WE("send_supernode_blockchain_based_list", on_supernode_blockchain_based_list,  COMMAND_RPC_SUPERNODE_GET_BLOCKCHAIN_BASED_LIST)
-        MAP_JON_RPC_WE("get_stats", on_get_rta_stats,  COMMAND_RPC_RTA_STATS)
+        MAP_JON_RPC_WE_IF("get_tunnels",              on_get_tunnels,              COMMAND_RPC_TUNNEL_DATA, !m_restricted)
+        MAP_JON_RPC_WE_IF("send_supernode_stakes",    on_supernode_stakes,         COMMAND_RPC_SUPERNODE_GET_STAKES, !m_restricted)
+        MAP_JON_RPC_WE_IF("send_supernode_blockchain_based_list", on_supernode_blockchain_based_list,  COMMAND_RPC_SUPERNODE_GET_BLOCKCHAIN_BASED_LIST, !m_restricted)
+        MAP_JON_RPC_WE_IF("get_stats", on_get_rta_stats,  COMMAND_RPC_RTA_STATS, !m_restricted)
       END_JSON_RPC_MAP()
     END_URI_MAP2()
 

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -1050,7 +1050,7 @@ namespace tools
         return false;
       }
       const cryptonote::account_public_address& supernode_public_address = dsts.front().addr;
-      std::string supernode_public_address_str = cryptonote::get_account_address_as_str(m_wallet->testnet(), supernode_public_address);
+      std::string supernode_public_address_str = cryptonote::get_account_address_as_str(m_wallet->nettype(), dsts.front().is_subaddress, supernode_public_address);
       std::string data = supernode_public_address_str + ":" + req.supernode_public_id;
       crypto::hash hash;
       crypto::cn_fast_hash(data.data(), data.size(), hash);

--- a/src/wallet/wallet_rpc_server.cpp
+++ b/src/wallet/wallet_rpc_server.cpp
@@ -835,73 +835,6 @@ namespace tools
       return false;
     }
 
-    if (req.stake_transfer) {
-      crypto::signature supernode_signature;
-      if (!epee::string_tools::hex_to_pod(req.supernode_signature, supernode_signature))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE;
-        er.message = "failed to parse supernode signature";
-        return false;
-      }
-
-      crypto::public_key W;
-      if (!epee::string_tools::hex_to_pod(req.supernode_public_id, W) || !check_key(W))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_WRONG_SUPERNODE_KEY;
-        er.message = "invalid supernode public identifier";
-        return false;
-      }
-      const cryptonote::account_public_address& supernode_public_address = dsts.front().addr;
-      std::string supernode_public_address_str = cryptonote::get_account_address_as_str(m_wallet->testnet(), supernode_public_address);
-      std::string data = supernode_public_address_str + ":" + req.supernode_public_id;
-      crypto::hash hash;
-      crypto::cn_fast_hash(data.data(), data.size(), hash);
-
-      if (!crypto::check_signature(hash, W, supernode_signature))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE;
-        er.message = "invalid supernode signature";
-        return false;
-      }
-
-      auto current_height = m_wallet->get_blockchain_current_height();
-      if (req.unlock_time < current_height + config::graft::STAKE_MIN_UNLOCK_TIME_FOR_WALLET)
-      {
-        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
-        er.message = "unlock_time is too low";
-        return false;
-      }
-
-      if (req.unlock_time > current_height + config::graft::STAKE_MAX_UNLOCK_TIME)
-      {
-        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
-        er.message = "unlock_time is too high";
-        return false;
-      }
-
-      if (dsts.size() != 1)
-      {
-        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
-        er.message = "stake transfer must go to exactly one recipient";
-        return false;
-      }
-
-      uint64_t amount = dsts.front().amount;
-      if (amount < config::graft::TIER1_STAKE_AMOUNT && !req.allow_low_stake)
-      {
-        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
-        er.message = "staked amount is too low";
-        return false;
-      }
-
-      if (!add_graft_stake_tx_extra_to_extra(extra, req.supernode_public_id, supernode_public_address, supernode_signature))
-      {
-        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
-        er.message = "failed to add stake transaction extra fields";
-        return false;
-      }
-    }
-
     try
     {
       uint64_t mixin;
@@ -1098,6 +1031,73 @@ namespace tools
     if (!validate_transfer(req.destinations, req.payment_id, dsts, extra, true, er))
     {
       return false;
+    }
+    
+    if (req.stake_transfer) {
+      crypto::signature supernode_signature;
+      if (!epee::string_tools::hex_to_pod(req.supernode_signature, supernode_signature))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE;
+        er.message = "failed to parse supernode signature";
+        return false;
+      }
+
+      crypto::public_key W;
+      if (!epee::string_tools::hex_to_pod(req.supernode_public_id, W) || !check_key(W))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_WRONG_SUPERNODE_KEY;
+        er.message = "invalid supernode public identifier";
+        return false;
+      }
+      const cryptonote::account_public_address& supernode_public_address = dsts.front().addr;
+      std::string supernode_public_address_str = cryptonote::get_account_address_as_str(m_wallet->testnet(), supernode_public_address);
+      std::string data = supernode_public_address_str + ":" + req.supernode_public_id;
+      crypto::hash hash;
+      crypto::cn_fast_hash(data.data(), data.size(), hash);
+
+      if (!crypto::check_signature(hash, W, supernode_signature))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_WRONG_SIGNATURE;
+        er.message = "invalid supernode signature";
+        return false;
+      }
+
+      auto current_height = m_wallet->get_blockchain_current_height();
+      if (req.unlock_time < current_height + config::graft::STAKE_MIN_UNLOCK_TIME_FOR_WALLET)
+      {
+        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
+        er.message = "unlock_time is too low";
+        return false;
+      }
+
+      if (req.unlock_time > current_height + config::graft::STAKE_MAX_UNLOCK_TIME)
+      {
+        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
+        er.message = "unlock_time is too high";
+        return false;
+      }
+
+      if (dsts.size() != 1)
+      {
+        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
+        er.message = "stake transfer must go to exactly one recipient";
+        return false;
+      }
+
+      uint64_t amount = dsts.front().amount;
+      if (amount < config::graft::TIER1_STAKE_AMOUNT && !req.allow_low_stake)
+      {
+        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
+        er.message = "staked amount is too low";
+        return false;
+      }
+
+      if (!add_graft_stake_tx_extra_to_extra(extra, req.supernode_public_id, supernode_public_address, supernode_signature))
+      {
+        er.code = WALLET_RPC_ERROR_CODE_GENERIC_TRANSFER_ERROR;
+        er.message = "failed to add stake transaction extra fields";
+        return false;
+      }
     }
 
     try

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -169,6 +169,11 @@ namespace wallet_rpc
       uint32_t account_index;
       std::string label;
 
+      bool stake_transfer;
+      std::string supernode_public_id;
+      std::string supernode_signature;
+      bool allow_low_stake;
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
         KV_SERIALIZE(label)
@@ -600,6 +605,11 @@ namespace wallet_rpc
         KV_SERIALIZE(auth_sample_height)
         KV_SERIALIZE_OPT(do_not_relay, false)
         KV_SERIALIZE_OPT(get_tx_hex, false)
+
+        KV_SERIALIZE_OPT(stake_transfer, false)
+        KV_SERIALIZE(supernode_public_id)
+        KV_SERIALIZE(supernode_signature)
+        KV_SERIALIZE_OPT(allow_low_stake, false)
       END_KV_SERIALIZE_MAP()
     };
 

--- a/src/wallet/wallet_rpc_server_commands_defs.h
+++ b/src/wallet/wallet_rpc_server_commands_defs.h
@@ -169,11 +169,6 @@ namespace wallet_rpc
       uint32_t account_index;
       std::string label;
 
-      bool stake_transfer;
-      std::string supernode_public_id;
-      std::string supernode_signature;
-      bool allow_low_stake;
-
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(account_index)
         KV_SERIALIZE(label)
@@ -487,6 +482,11 @@ namespace wallet_rpc
       bool get_tx_hex;
       bool get_tx_metadata;
 
+      bool stake_transfer;
+      std::string supernode_public_id;
+      std::string supernode_signature;
+      bool allow_low_stake;
+
       BEGIN_KV_SERIALIZE_MAP()
         KV_SERIALIZE(destinations)
         KV_SERIALIZE(account_index)
@@ -500,6 +500,10 @@ namespace wallet_rpc
         KV_SERIALIZE_OPT(do_not_relay, false)
         KV_SERIALIZE_OPT(get_tx_hex, false)
         KV_SERIALIZE_OPT(get_tx_metadata, false)
+        KV_SERIALIZE_OPT(stake_transfer, false)
+        KV_SERIALIZE(supernode_public_id)
+        KV_SERIALIZE(supernode_signature)
+        KV_SERIALIZE_OPT(allow_low_stake, false)
       END_KV_SERIALIZE_MAP()
     };
 
@@ -605,11 +609,6 @@ namespace wallet_rpc
         KV_SERIALIZE(auth_sample_height)
         KV_SERIALIZE_OPT(do_not_relay, false)
         KV_SERIALIZE_OPT(get_tx_hex, false)
-
-        KV_SERIALIZE_OPT(stake_transfer, false)
-        KV_SERIALIZE(supernode_public_id)
-        KV_SERIALIZE(supernode_signature)
-        KV_SERIALIZE_OPT(allow_low_stake, false)
       END_KV_SERIALIZE_MAP()
     };
 


### PR DESCRIPTION
Don't provide RTA-related RPC endpoints in restricted mode 

https://github.com/graft-community/GraftNetwork/commit/c19d6dcf6fea78ad99001f9583ea4de025c5e8e4
--------------------------------------
Adds staking ability to transfer_split RPC 

https://github.com/graft-community/GraftNetwork/commit/374d76f528d64dde6c52e4b24cca847de704ef9a
--
Added parameters are:

    stake_transfer - must be true to do a staking transfer
    supernode_public_id - the SN pubkey
    supernode_signature - a SN signature value
    allow_low_stake - set to true to allow staking less than a T1 (for
                      example, to submit an "upgrade" stake amount).

The transfer must also be sent to a single address (which has to match
the one configured in the SN for the signature to be valid).