### PR TITLE
wallet's ringdb: using one 'MDB_env*' instance per process (#310)

### DIFF
--- a/src/wallet/ringdb.h
+++ b/src/wallet/ringdb.h
@@ -60,8 +60,9 @@ namespace tools
 
   private:
     std::string filename;
-    MDB_env *env;
+    static MDB_env *env;
     MDB_dbi dbi_rings;
     MDB_dbi dbi_blackballs;
+    static int ref_counter;
   };
 }


### PR DESCRIPTION
fixes #310 